### PR TITLE
support for lower temperatures

### DIFF
--- a/app.json
+++ b/app.json
@@ -871,7 +871,7 @@
         },
         "target_temperature": {
           "decimals": 0,
-          "min": 16,
+          "min": 10,
           "max": 30,
           "step": 1
         }

--- a/drivers/Sensibo/device.js
+++ b/drivers/Sensibo/device.js
@@ -408,7 +408,7 @@ module.exports = class SensiboDevice extends Homey.Device {
         on: on !== 'nop' ? on === 'on' : undefined,
         mode: mode !== 'nop' ? mode : undefined,
         fanLevel: fanLevel !== 'nop' ? fanLevel : undefined,
-        targetTemperature: targetTemperature >= 16 ? targetTemperature : undefined,
+        targetTemperature: targetTemperature >= 16 or targetTemperature == 10 ? targetTemperature : undefined,
       };
       if (minutesFromNow <= 0) {
         throw new Error('Minutes from now must be specified.');

--- a/drivers/Sensibo/driver.compose.json
+++ b/drivers/Sensibo/driver.compose.json
@@ -25,7 +25,7 @@
     },
     "target_temperature": {
       "decimals": 0,
-      "min": 16,
+      "min": 10,
       "max": 30,
       "step": 1
     }


### PR DESCRIPTION
**Changes**:
- changing lowest temperature from 16 to 10
- adjusting if statement to undefine values 11-15

**Comment**:
Sensibo devices support temperatures as low as 10 degrees.

**Onresolved**:
The "sad" thing is that it's not supporting temperature 11-15, so I'm not really sure what the handling should be.. now it should return _undefined_ if the temperature is in that invalid ranges.
Is there maybe some option to do two ranges in the _target_temperature_ part?
https://github.com/tobiasehlert/com.sensibo/blob/45e31aef527f63e8c292275747db58f8aa7426f2/drivers/Sensibo/driver.compose.json#L26-L31
